### PR TITLE
Fix URI of the WebSocket Resources page

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -45,7 +45,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
   <LinkCard title="WebSocket Echo Server" icon="pencil" href="/tools/websocket-echo-server/">
     Edit `src/content/docs/index.mdx` to see this page change.
   </LinkCard>
-  <LinkCard title="WebSocket Resources" icon="pencil" href="/tools/websocket-resources/">
+  <LinkCard title="WebSocket Resources" icon="pencil" href="/resources/websocket-resources/">
 		Edit `src/content/docs/index.mdx` to see this page change.
 	</LinkCard>
 </CardGrid>


### PR DESCRIPTION
This patch attempts to fix the problem where the original URI leads to the 404 not found error page.

![Screenshot](https://github.com/ably/websocket.org/assets/13408130/8a2312ea-445d-4d2c-8299-c7d8f3f5be33)

This is made on mere observation of the code and is not tested, please review.