### PR TITLE
fix: mention vercel sandbox

### DIFF
--- a/src/content/docs/guides/future-of-websockets.md
+++ b/src/content/docs/guides/future-of-websockets.md
@@ -230,6 +230,7 @@ Key benefits:
 | **Google Cloud** | Load Balancer | ✅ Available    | ⚠️ Beta               | HTTP/3 in preview                        |
 | **Azure**        | Front Door    | ✅ Available    | ⚠️ Limited            | HTTP/3 support, WebSocket limitations    |
 | **Fastly**       | CDN           | ✅ Full Support | ✅ Full Support       | QUIC and HTTP/3 enabled                  |
+| **Vercel**       | Sandbox       | ❌ Not Available| ❌ Not Available      | Sandbox-only at this time.               |
 
 ### Implementation Reality Check (2025)
 

--- a/src/content/docs/guides/future-of-websockets.md
+++ b/src/content/docs/guides/future-of-websockets.md
@@ -230,7 +230,7 @@ Key benefits:
 | **Google Cloud** | Load Balancer | ✅ Available    | ⚠️ Beta               | HTTP/3 in preview                        |
 | **Azure**        | Front Door    | ✅ Available    | ⚠️ Limited            | HTTP/3 support, WebSocket limitations    |
 | **Fastly**       | CDN           | ✅ Full Support | ✅ Full Support       | QUIC and HTTP/3 enabled                  |
-| **Vercel**       | Sandbox       | ❌ Not Available| ❌ Not Available      | Sandbox-only at this time.               |
+| **Vercel**       | CDN       | ❌ Not Available| ❌ Not Available      | ✅ Full                |
 
 ### Implementation Reality Check (2025)
 

--- a/src/content/docs/standards/index.mdx
+++ b/src/content/docs/standards/index.mdx
@@ -172,6 +172,7 @@ Next-generation bidirectional communication protocol built on HTTP/3.
 | Google Cloud LB   | ✅                | ✅     | 🚧     | Global load balancing     |
 | Azure App Gateway | ✅                | ✅     | ❌     | Session affinity required |
 | Fastly            | ✅                | ✅     | ✅     | Real-time purging         |
+| Vercel Sandbox    | ✅                | ✅     | ❌     | Sandbox-only at this time |
 
 ## What's New - December 2024
 

--- a/src/content/docs/standards/index.mdx
+++ b/src/content/docs/standards/index.mdx
@@ -172,7 +172,7 @@ Next-generation bidirectional communication protocol built on HTTP/3.
 | Google Cloud LB   | ✅                | ✅     | 🚧     | Global load balancing     |
 | Azure App Gateway | ✅                | ✅     | ❌     | Session affinity required |
 | Fastly            | ✅                | ✅     | ✅     | Real-time purging         |
-| Vercel Sandbox    | ✅                | ✅     | ❌     | Sandbox-only at this time |
+| Vercel          | ✅                | ✅     | ❌     | timeout 24h sandbox and 30min function |
 
 ## What's New - December 2024
 


### PR DESCRIPTION
Vercel launched Sandbox a few months ago which brings support for Websockets to the platform.

https://vercel.com/changelog/run-untrusted-code-with-vercel-sandbox