### PR TITLE
Fix exponential backoff in javascript url

### DIFF
--- a/src/content/docs/resources/websocket-resources.md
+++ b/src/content/docs/resources/websocket-resources.md
@@ -234,8 +234,8 @@ For a comprehensive comparison of the best WebSocket libraries for Node.js, see
   Step-by-step tutorial
 - [WebSocket Security - Cross-Site Hijacking](https://www.christian-schneider.net/CrossSiteWebSocketHijacking.html) -
   Security best practices
-- [Exponential Backoff in JavaScript](https://advancedweb.hu/exponential-backoff-javascript/) -
-  Reconnection strategies
+- [Exponential Backoff in JavaScript](https://advancedweb.hu/how-to-implement-an-exponential-backoff-retry-strategy-in-javascript/)
+  \- Reconnection strategies
 - [Patterns for Building Realtime Features](https://ably.com/blog/patterns-for-building-realtime-features) -
   Architectural patterns and best practices
 


### PR DESCRIPTION
### Issue
The `Exponential Backoff in JavaScript` link in the [Implementation Guides](https://websocket.org/resources/websocket-resources/#implementation-guides) docs leads to a 404 page:

<img width="1365" height="489" alt="Screenshot 2025-11-17 at 1 51 52 AM" src="https://github.com/user-attachments/assets/dfeaf759-0b89-42b5-8488-f5bbe31664e8" />

### Fix
I think [this is the new URL](https://advancedweb.hu/how-to-implement-an-exponential-backoff-retry-strategy-in-javascript/) for that exponential backoff article. This PR just updates the URL in the docs to the new one