### PR TITLE
Clarify Cloudfront support for modern HTTP protocols

### DIFF
--- a/src/content/docs/guides/future-of-websockets.md
+++ b/src/content/docs/guides/future-of-websockets.md
@@ -225,11 +225,11 @@ Key benefits:
 
 | Provider         | Service       | HTTP/3 Support  | WebSocket over HTTP/3 | Notes                                    |
 | ---------------- | ------------- | --------------- | --------------------- | ---------------------------------------- |
-| **Cloudflare**   | CDN           | ✅ Full Support | ✅ Full Support       | Automatic HTTP/3 upgrade                 |
-| **AWS**          | CloudFront    | ✅ Available    | ⚠️ Limited            | HTTP/3 enabled, WebSocket support varies |
-| **Google Cloud** | Load Balancer | ✅ Available    | ⚠️ Beta               | HTTP/3 in preview                        |
-| **Azure**        | Front Door    | ✅ Available    | ⚠️ Limited            | HTTP/3 support, WebSocket limitations    |
-| **Fastly**       | CDN           | ✅ Full Support | ✅ Full Support       | QUIC and HTTP/3 enabled                  |
+| **Cloudflare**   | CDN           | ✅ Full Support | ✅ Full Support       | Automatic HTTP/3 upgrade                  |
+| **AWS**          | CloudFront    | ✅ Available    | ❌ Not Available      | HTTP/3 enabled, WebSockets HTTP/1 only    |
+| **Google Cloud** | Load Balancer | ✅ Available    | ⚠️ Beta               | HTTP/3 in preview                         |
+| **Azure**        | Front Door    | ✅ Available    | ⚠️ Limited            | HTTP/3 support, WebSocket limitations     |
+| **Fastly**       | CDN           | ✅ Full Support | ✅ Full Support       | QUIC and HTTP/3 enabled                   |
 
 ### Implementation Reality Check (2025)
 


### PR DESCRIPTION
Per https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-working-with.websockets.html:

> Currently, CloudFront only supports WebSocket connections over the HTTP/1.1 protocol.